### PR TITLE
LCD: Add capability to override LCD output pin assignments if pins moved

### DIFF
--- a/libraries/LCD/LCD.h
+++ b/libraries/LCD/LCD.h
@@ -49,6 +49,9 @@ class LCD : public LiquidCrystal {
 public:
     LCD() : LiquidCrystal(8, 9, 4, 5, 6, 7) { init(); }
     LCD(uint8_t pin9) : LiquidCrystal(8, pin9, 4, 5, 6, 7) { init(); }
+    LCD(uint8_t rs, uint8_t enable,
+        uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3)
+      : LiquidCrystal(rs, enable, d0, d1, d2, d3) { init(); }
 
     uint8_t backlightPin() const { return _backlightPin; }
     void setBacklightPin(uint8_t pin);


### PR DESCRIPTION
Hi Rhys,

Thanks for all your work creating and sharing these libraries, we really appreciate it!

We had a customer ask about using the LCD library with alternative pin assignments, so this commit adds an additional constructor overload to change the assigned display pins.

If you don't mind as well, I'd like to link this library from the LCD & Keypad shield homepage.

Regards,

Angus
