### PR TITLE
Bump @PlatformIO Crypto library version to 0.1.1

### DIFF
--- a/libraries/Crypto/library.json
+++ b/libraries/Crypto/library.json
@@ -1,6 +1,6 @@
 {
     "name": "Crypto",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "keywords": "AES128,AES192,AES256,Speck,CTR,CFB,CBC,OFB,EAX,GCM,XTS,ChaCha,ChaChaPoly,EAX,GCM,SHA256,SHA512,SHA3_256,SHA3_512,BLAKE2s,BLAKE2b,SHAKE128,SHAKE256,Poly1305,GHASH,OMAC,Curve25519,Ed25519,P521,RNG,NOISE",
     "description": "Arduino CryptoLibs - All cryptographic algorithms have been optimized for 8-bit Arduino platforms like the Uno",
     "authors":


### PR DESCRIPTION
The following changes haven't been commited the PlatformIO registry for Crypto.
http://platformio.org/lib/show/1168/Crypto

8b89c1fbb51087c92ee86934929d090b02ff6b1b Fix warning in LimbUtil.h 
a4683416ff0773ee85d538d1f6a648b9d0523c8c Fix compilation error for ESP8266

Bumping the version should trigger the library to update after a day.