### PR TITLE
[ESP8266]Moving Inline Fuction to its own header

### DIFF
--- a/libraries/Crypto/Crypto.h
+++ b/libraries/Crypto/Crypto.h
@@ -25,16 +25,7 @@
 
 #include <inttypes.h>
 #include <stddef.h>
-
-void clean(void *dest, size_t size);
-
-template <typename T>
-inline void clean(T &var)
-{
-    clean(&var, sizeof(T));
-}
-
-bool secure_compare(const void *data1, const void *data2, size_t len);
+#include "Inludes.h"
 
 #if defined(ESP8266)
 extern "C" void system_soft_wdt_feed(void);

--- a/libraries/Crypto/Inlines.h
+++ b/libraries/Crypto/Inlines.h
@@ -1,0 +1,13 @@
+#ifndef INLINES_H
+#define INLINES_H
+
+extern bool secure_compare(const void *data1, const void *data2, size_t len);
+extern void clean(void *dest, size_t size);
+
+
+template <typename T>
+inline void clean(T &var)
+{
+    clean(&var, sizeof(T));
+}
+#endif

--- a/libraries/CryptoLW/src/Acorn128.h
+++ b/libraries/CryptoLW/src/Acorn128.h
@@ -24,6 +24,7 @@
 #define CRYPTO_ACORN128_H
 
 #include "AuthenticatedCipher.h"
+#include "Inludes.h"
 
 /** @cond acorn128_state */
 

--- a/libraries/CryptoLW/src/Ascon128.h
+++ b/libraries/CryptoLW/src/Ascon128.h
@@ -24,6 +24,7 @@
 #define CRYPTO_ASCON128_H
 
 #include "AuthenticatedCipher.h"
+#include "Inludes.h"
 
 class Ascon128 : public AuthenticatedCipher
 {

--- a/libraries/CryptoLW/src/Speck.h
+++ b/libraries/CryptoLW/src/Speck.h
@@ -24,6 +24,7 @@
 #define CRYPTO_SPECK_H
 
 #include "BlockCipher.h"
+#include "Inludes.h"
 
 class Speck : public BlockCipher
 {

--- a/libraries/CryptoLW/src/SpeckSmall.h
+++ b/libraries/CryptoLW/src/SpeckSmall.h
@@ -24,6 +24,7 @@
 #define CRYPTO_SPECK_SMALL_H
 
 #include "SpeckTiny.h"
+#include "Inludes.h"
 
 class SpeckSmall : public SpeckTiny
 {

--- a/libraries/CryptoLW/src/SpeckTiny.h
+++ b/libraries/CryptoLW/src/SpeckTiny.h
@@ -24,6 +24,7 @@
 #define CRYPTO_SPECK_TINY_H
 
 #include "BlockCipher.h"
+#include "Inludes.h"
 
 class SpeckSmall;
 


### PR DESCRIPTION
This should fix compilation for ESP8266 controllers
The inline function should not increase size if done like this.
other wierd thing i found is naming of headers...
had use absolute path for header since ESP8266 already creates a Crypto.h
`#include "D:\...\Arduino\libraries\Crypto\src\Crypto.h"`
feel free to rename the Inlines.h since thats probably also a name that someone might use...
please check compatibility before merging dont want to interupt work if i accidently broke something