### PR TITLE
Conflict resolution for Arduino_Core_STM32

### DIFF
--- a/libraries/Crypto/RNG.cpp
+++ b/libraries/Crypto/RNG.cpp
@@ -173,7 +173,9 @@
  *
  * \sa RNGClass
  */
+#ifndef RNG
 RNGClass RNG;
+#endif
 
 /**
  * \var RNGClass::SEED_SIZE

--- a/libraries/Crypto/RNG.h
+++ b/libraries/Crypto/RNG.h
@@ -69,6 +69,10 @@ private:
     void mixTRNG();
 };
 
+/* the STM32 tolkit defines its own RNG symbol, incompatible with the
+   Crypto library: https://github.com/stm32duino/Arduino_Core_STM32 */
+#ifndef RNG
 extern RNGClass RNG;
+#endif
 
 #endif


### PR DESCRIPTION
https://github.com/stm32duino/Arduino_Core_STM32   defines RNG as something different, and that prevents the Crypto library from compiling.