### PR TITLE
Fix building with MinGW x64

### DIFF
--- a/libraries/Crypto/BigNumberUtil.h
+++ b/libraries/Crypto/BigNumberUtil.h
@@ -34,7 +34,7 @@
 #define BIGNUMBER_LIMB_16BIT 1
 #define BIGNUMBER_LIMB_32BIT 0
 #define BIGNUMBER_LIMB_64BIT 0
-#elif defined(__GNUC__) && __WORDSIZE == 64
+#elif defined(__GNUC__) && (__x86_64__ || __ppc64__)
 // 64-bit system with 128-bit double limbs.
 #define BIGNUMBER_LIMB_8BIT  0
 #define BIGNUMBER_LIMB_16BIT 0


### PR DESCRIPTION
It's a minor fix to compile tests on mingw compiler from MSys2.

For some reason actual mingw version doesn't include `__WORDSIZE` definition with your common includes `#include <inttypes.h> #include <stddef.h>`
But it's included somewhere in `Arduino.cpp` (haven't checked, is it `stdio.h` or `time.h`).
In that case `BigNumberUtil.cpp` compiled with `BIGNUMBER_LIMB_32BIT`, but all .ino tests compiled with `BIGNUMBER_LIMB_64BIT`.

Fixed code works well both with mingw and original linux gcc (I cannot check Mac version).